### PR TITLE
Fix:#75 Vertically center Google Icon in login page

### DIFF
--- a/client/src/pages/Login/index.tsx
+++ b/client/src/pages/Login/index.tsx
@@ -88,6 +88,7 @@ const Login = () => {
                 zIndex: 101,
                 '& .MuiButton-startIcon': {
                   marginRight: theme.spacing(3),
+                  marginTop: theme.spacing(-0.55), // Adjusted margin
                 },
               }),
             ]}


### PR DESCRIPTION
Closes #75  Add negative margin top on Google Icon to align with the text. 
Try flex also but that didn't worked inspect the code a lot but nothing worked just this negative margin worked to align the google icon with the text. 