### PR TITLE
fix: remove attendees by backspace(#130)

### DIFF
--- a/client/src/components/ChipInput.tsx
+++ b/client/src/components/ChipInput.tsx
@@ -18,7 +18,11 @@ export default function ChipInput({ id, sx, onChange, value, type }: ChipInputPr
   const [chips, setChips] = useState<any[]>(value || []);
 
   const handleKeyDown = (event: any) => {
-    if ((event.key === 'Enter' || event.key === ' ') && inputValue.trim() !== '') {
+    if (event.key === 'Backspace' && inputValue === '' && chips.length > 0) {
+      const newChips = chips.slice(0, -1);
+      setChips(newChips);
+      onChange(id, newChips);
+    } else if ((event.key === 'Enter' || event.key === ' ') && inputValue.trim() !== '') {
       if (validateEmail(inputValue.trim())) {
         const newChips = [...chips, inputValue.trim()];
         setChips(newChips);


### PR DESCRIPTION
## Description
Attendees can now be removed with backspace when no email content is available.

## Demo

![issue-130](https://github.com/user-attachments/assets/49bc166c-dd85-48f1-8dc2-9222a9c36a71)
