### PR TITLE
Feat/issue 163 - Attendee Profile photo and Name to be displayed in the suggestions

### DIFF
--- a/client/src/components/AttendeeInput.tsx
+++ b/client/src/components/AttendeeInput.tsx
@@ -6,6 +6,7 @@ import { isEmailValid } from '@/helpers/utility';
 import toast from 'react-hot-toast';
 import Avatar from '@mui/material/Avatar';
 import { Typography } from '@mui/material';
+import type { IAttendeeInformation } from '@quickmeet/shared';
 
 interface AttendeeInputProps {
   id: string;
@@ -16,7 +17,7 @@ interface AttendeeInputProps {
 }
 
 export default function AttendeeInput({ id, onChange, value, type }: AttendeeInputProps) {
-  const [options, setOptions] = useState<string[]>([]);
+  const [options, setOptions] = useState<IAttendeeInformation[]>([]);
   const [textInput, setTextInput] = useState('');
 
   const api = useApi();
@@ -25,7 +26,7 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
     if (newInputValue.length > 2) {
       const res = await api.searchPeople(newInputValue);
       if (res.status === 'success') {
-        setOptions(res.data || []);
+        setOptions((res.data as IAttendeeInformation[]) || []);
       }
     }
   };
@@ -110,7 +111,8 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
           multiple
           options={options}
           value={value || []}
-          getOptionLabel={(option) => option}
+          getOptionLabel={(option) => (typeof option === 'object' && option.name ? option.name : '')}
+          noOptionsText=""
           freeSolo
           inputValue={textInput}
           fullWidth
@@ -133,10 +135,10 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
             },
           }}
           onInputChange={debouncedInputChange}
-          renderTags={(value: readonly string[], getTagProps) =>
-            value.map((option: string, index: number) => {
+          renderTags={(value: readonly { name: string }[], getTagProps) =>
+            value.map((option: { name: string }, index: number) => {
               const { key, ...tagProps } = getTagProps({ index });
-              return <Chip variant="filled" label={option} key={key} {...tagProps} />;
+              return <Chip variant="filled" label={option.name} key={key} {...tagProps} />;
             })
           }
           renderInput={(params) => (

--- a/client/src/components/AttendeeInput.tsx
+++ b/client/src/components/AttendeeInput.tsx
@@ -6,7 +6,7 @@ import { isEmailValid } from '@/helpers/utility';
 import toast from 'react-hot-toast';
 import Avatar from '@mui/material/Avatar';
 import { Typography } from '@mui/material';
-import type { IAttendeeInformation } from '@quickmeet/shared';
+import type { IPeopleInformation } from '@quickmeet/shared';
 
 interface AttendeeInputProps {
   id: string;
@@ -17,7 +17,7 @@ interface AttendeeInputProps {
 }
 
 export default function AttendeeInput({ id, onChange, value, type }: AttendeeInputProps) {
-  const [options, setOptions] = useState<IAttendeeInformation[]>([]);
+  const [options, setOptions] = useState<IPeopleInformation[]>([]);
   const [textInput, setTextInput] = useState('');
 
   const api = useApi();
@@ -26,7 +26,7 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
     if (newInputValue.length > 2) {
       const res = await api.searchPeople(newInputValue);
       if (res.status === 'success') {
-        setOptions((res.data as IAttendeeInformation[]) || []);
+        setOptions((res.data as IPeopleInformation[]) || []);
       }
     }
   };
@@ -69,7 +69,7 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
 
   const debouncedInputChange = debounce(handleInputChange, 300);
 
-  const filteredEmails = (newValue: Array<string | IAttendeeInformation>): string[] => {
+  const filteredEmails = (newValue: Array<string | IPeopleInformation>): string[] => {
     const emails = newValue.map((option) => (typeof option === 'object' && option.email ? option.email : (option as string)));
     return emails.filter((email) => emails.indexOf(email) === emails.lastIndexOf(email));
   };

--- a/client/src/components/AttendeeInput.tsx
+++ b/client/src/components/AttendeeInput.tsx
@@ -179,13 +179,13 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
             const { key, ...optionProps } = props;
             return (
               <Box key={key} component="li" sx={{ '& > img': { mr: 2, flexShrink: 0 } }} {...optionProps} gap={1}>
-                <Avatar src="https://avatars.githubusercontent.com/u/63257806?v=4" alt={`Image of ${option}`} />
+                <Avatar src={option.photo} alt={`Image of ${option.name}`} />
                 <Box>
                   <Typography variant="subtitle1" noWrap={true} width={250}>
-                    Name of the person
+                    {option.name}
                   </Typography>
                   <Typography variant="subtitle2" color="text.secondary" noWrap={true} width={250}>
-                    {option}
+                    {option.email}
                   </Typography>
                 </Box>
               </Box>

--- a/client/src/components/AttendeeInput.tsx
+++ b/client/src/components/AttendeeInput.tsx
@@ -71,8 +71,7 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
 
   const filteredEmails = (newValue: Array<string | IAttendeeInformation>): string[] => {
     const emails = newValue.map((option) => (typeof option === 'object' && option.email ? option.email : (option as string)));
-    const filteredEmails = emails.filter((email) => emails.indexOf(email) === emails.lastIndexOf(email));
-    return filteredEmails;
+    return emails.filter((email) => emails.indexOf(email) === emails.lastIndexOf(email));
   };
 
   return (
@@ -117,7 +116,7 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
           multiple
           options={options}
           value={value || []}
-          getOptionLabel={(option) => (typeof option === 'object' && option.name ? option.name : '')}
+          getOptionLabel={(option) => (typeof option === 'object' && option.email ? option.email : '')}
           noOptionsText=""
           freeSolo
           inputValue={textInput}
@@ -144,7 +143,7 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
           }}
           onInputChange={debouncedInputChange}
           renderTags={(value: readonly string[], getTagProps) =>
-            value.map((email, index) => {
+            value.map((email: string, index: number) => {
               const { key, ...tagProps } = getTagProps({ index });
               return <Chip variant="filled" label={email} key={key} {...tagProps} />;
             })

--- a/client/src/components/AttendeeInput.tsx
+++ b/client/src/components/AttendeeInput.tsx
@@ -69,6 +69,12 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
 
   const debouncedInputChange = debounce(handleInputChange, 300);
 
+  const filteredEmails = (newValue: Array<string | IAttendeeInformation>): string[] => {
+    const emails = newValue.map((option) => (typeof option === 'object' && option.email ? option.email : (option as string)));
+    const filteredEmails = emails.filter((email) => emails.indexOf(email) === emails.lastIndexOf(email));
+    return filteredEmails;
+  };
+
   return (
     <Box
       display="flex"
@@ -116,7 +122,9 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
           freeSolo
           inputValue={textInput}
           fullWidth
-          onChange={handleSelectionChange}
+          onChange={(_, newValue) => {
+            handleSelectionChange(_, filteredEmails(newValue));
+          }}
           slotProps={{
             listbox: {
               sx: {
@@ -135,10 +143,10 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
             },
           }}
           onInputChange={debouncedInputChange}
-          renderTags={(value: readonly { name: string }[], getTagProps) =>
-            value.map((option: { name: string }, index: number) => {
+          renderTags={(value: readonly string[], getTagProps) =>
+            value.map((email, index) => {
               const { key, ...tagProps } = getTagProps({ index });
-              return <Chip variant="filled" label={option.name} key={key} {...tagProps} />;
+              return <Chip variant="filled" label={email} key={key} {...tagProps} />;
             })
           }
           renderInput={(params) => (
@@ -179,11 +187,18 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
           )}
           renderOption={(props, option) => {
             const { key, ...optionProps } = props;
+            const isSelected = value?.includes(option.email);
             return (
-              <Box key={key} component="li" sx={{ '& > img': { mr: 2, flexShrink: 0 } }} {...optionProps} gap={1}>
+              <Box
+                key={key}
+                component="li"
+                sx={{ '& > img': { mr: 2, flexShrink: 0 }, backgroundColor: isSelected ? 'rgba(0, 0, 0, 0.08)' : 'transparent' }}
+                {...optionProps}
+                gap={1}
+              >
                 <Avatar src={option.photo} alt={`Image of ${option.name}`} />
                 <Box>
-                  <Typography variant="subtitle1" noWrap={true} width={250}>
+                  <Typography variant="subtitle2" noWrap={true} width={250}>
                     {option.name}
                   </Typography>
                   <Typography variant="subtitle2" color="text.secondary" noWrap={true} width={250}>

--- a/client/src/components/AttendeeInput.tsx
+++ b/client/src/components/AttendeeInput.tsx
@@ -191,7 +191,12 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
               <Box
                 key={key}
                 component="li"
-                sx={{ '& > img': { mr: 2, flexShrink: 0 }, backgroundColor: isSelected ? 'rgba(0, 0, 0, 0.08)' : 'transparent' }}
+                sx={[
+                  (theme) => ({
+                    '& > img': { mr: 2, flexShrink: 0 },
+                    backgroundColor: isSelected ? theme.palette.grey[100] : 'transparent',
+                  }),
+                ]}
                 {...optionProps}
                 gap={1}
               >

--- a/client/src/components/AttendeeInput.tsx
+++ b/client/src/components/AttendeeInput.tsx
@@ -31,17 +31,19 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
     }
   };
 
-  const handleSelectionChange = (_: React.SyntheticEvent, newValue: string[]) => {
-    if (newValue.length > 0) {
-      const lastValue = newValue[newValue.length - 1].trim();
+  const handleSelectionChange = (_: React.SyntheticEvent, newValue: Array<string | IPeopleInformation>) => {
+    const emails = newValue.map((option) => (typeof option === 'object' && option.email ? option.email : (option as string)));
+    const filteredEmails = emails.filter((email) => emails.indexOf(email) === emails.lastIndexOf(email));
+    if (filteredEmails.length > 0) {
+      const lastValue = filteredEmails[filteredEmails.length - 1].trim();
       if (isEmailValid(lastValue)) {
-        onChange(id, newValue);
+        onChange(id, filteredEmails);
         setTextInput('');
       } else {
         toast.error('Invalid email entered');
       }
     } else {
-      onChange(id, newValue);
+      onChange(id, filteredEmails);
       setTextInput('');
     }
   };
@@ -68,11 +70,6 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
   };
 
   const debouncedInputChange = debounce(handleInputChange, 300);
-
-  const filteredEmails = (newValue: Array<string | IPeopleInformation>): string[] => {
-    const emails = newValue.map((option) => (typeof option === 'object' && option.email ? option.email : (option as string)));
-    return emails.filter((email) => emails.indexOf(email) === emails.lastIndexOf(email));
-  };
 
   return (
     <Box
@@ -121,9 +118,7 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
           freeSolo
           inputValue={textInput}
           fullWidth
-          onChange={(_, newValue) => {
-            handleSelectionChange(_, filteredEmails(newValue));
-          }}
+          onChange={handleSelectionChange}
           slotProps={{
             listbox: {
               sx: {
@@ -201,11 +196,11 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
                 gap={1}
               >
                 <Avatar src={option.photo} alt={`Image of ${option.name}`} />
-                <Box>
-                  <Typography variant="subtitle2" noWrap={true} width={250}>
+                <Box sx={{ width: '80%' }}>
+                  <Typography variant="subtitle2" noWrap={true}>
                     {option.name}
                   </Typography>
-                  <Typography variant="subtitle2" color="text.secondary" noWrap={true} width={250}>
+                  <Typography variant="subtitle2" color="text.secondary" noWrap={true}>
                     {option.email}
                   </Typography>
                 </Box>

--- a/client/src/components/AttendeeInput.tsx
+++ b/client/src/components/AttendeeInput.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import { useApi } from '@/context/ApiContext';
 import { isEmailValid } from '@/helpers/utility';
 import toast from 'react-hot-toast';
+import Avatar from '@mui/material/Avatar';
+import { Typography } from '@mui/material';
 
 interface AttendeeInputProps {
   id: string;
@@ -173,6 +175,22 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
               ]}
             />
           )}
+          renderOption={(props, option) => {
+            const { key, ...optionProps } = props;
+            return (
+              <Box key={key} component="li" sx={{ '& > img': { mr: 2, flexShrink: 0 } }} {...optionProps} gap={1}>
+                <Avatar src="https://avatars.githubusercontent.com/u/63257806?v=4" alt={`Image of ${option}`} />
+                <Box>
+                  <Typography variant="subtitle1" noWrap={true} width={250}>
+                    Name of the person
+                  </Typography>
+                  <Typography variant="subtitle2" color="text.secondary" noWrap={true} width={250}>
+                    {option}
+                  </Typography>
+                </Box>
+              </Box>
+            );
+          }}
         />
       </Box>
     </Box>

--- a/server/src/calender/calender.controller.ts
+++ b/server/src/calender/calender.controller.ts
@@ -13,6 +13,7 @@ import {
   EventResponse,
   EventUpdateResponse,
   IConferenceRoom,
+  IAttendeeInformation,
 } from '@quickmeet/shared';
 import { createResponse } from 'src/helpers/payload.util';
 import { _Request } from 'src/auth/interfaces';
@@ -92,10 +93,10 @@ export class CalenderController {
   @UseGuards(AuthGuard)
   @UseInterceptors(OauthInterceptor)
   @Get('/directory/people')
-  async searchPeople(@_OAuth2Client() client: OAuth2Client, @Query('email') email: string): Promise<ApiResponse<string[]>> {
-    const emails = await this.calenderService.searchPeople(client, email);
+  async searchPeople(@_OAuth2Client() client: OAuth2Client, @Query('email') email: string): Promise<ApiResponse<IAttendeeInformation[]>> {
+    const peoples = await this.calenderService.searchPeople(client, email);
 
-    return createResponse(emails);
+    return createResponse(peoples);
   }
 
   @UseGuards(AuthGuard)

--- a/server/src/calender/calender.controller.ts
+++ b/server/src/calender/calender.controller.ts
@@ -13,7 +13,7 @@ import {
   EventResponse,
   EventUpdateResponse,
   IConferenceRoom,
-  IAttendeeInformation,
+  IPeopleInformation,
 } from '@quickmeet/shared';
 import { createResponse } from 'src/helpers/payload.util';
 import { _Request } from 'src/auth/interfaces';
@@ -93,7 +93,7 @@ export class CalenderController {
   @UseGuards(AuthGuard)
   @UseInterceptors(OauthInterceptor)
   @Get('/directory/people')
-  async searchPeople(@_OAuth2Client() client: OAuth2Client, @Query('email') email: string): Promise<ApiResponse<IAttendeeInformation[]>> {
+  async searchPeople(@_OAuth2Client() client: OAuth2Client, @Query('email') email: string): Promise<ApiResponse<IPeopleInformation[]>> {
     const peoples = await this.calenderService.searchPeople(client, email);
 
     return createResponse(peoples);

--- a/server/src/calender/calender.service.ts
+++ b/server/src/calender/calender.service.ts
@@ -3,7 +3,7 @@ import { BadRequestException, ConflictException, ForbiddenException, Inject, Inj
 import { calendar_v3 } from 'googleapis';
 import { extractRoomByEmail, isRoomAvailable, validateEmail } from './util/calender.util';
 import { AuthService } from '../auth/auth.service';
-import { DeleteResponse, EventResponse, EventUpdateResponse, IConferenceRoom } from '@quickmeet/shared';
+import { DeleteResponse, EventResponse, EventUpdateResponse, IConferenceRoom, IAttendeeInformation } from '@quickmeet/shared';
 import { GoogleApiService } from 'src/google-api/google-api.service';
 
 @Injectable()
@@ -417,18 +417,19 @@ export class CalenderService {
     return floors;
   }
 
-  async searchPeople(client: OAuth2Client, emailQuery: string): Promise<string[]> {
-    const people = await this.googleApiService.searchPeople(client, emailQuery);
-    const emails = [];
-    for (const p of people) {
-      for (const email of p.emailAddresses) {
-        if (email.metadata.primary && email.metadata.verified) {
-          emails.push(email.value);
-          break;
-        }
-      }
-    }
+  async searchPeople(client: OAuth2Client, emailQuery: string): Promise<IAttendeeInformation[]> {
+    const response = await this.googleApiService.searchPeople(client, emailQuery);
+    const peoples: IAttendeeInformation[] = response.map((people) => {
+      const email = people.emailAddresses.find((email) => email.metadata.primary && email.metadata.verified);
+      const photo = people.photos.find((photo) => photo.metadata.primary);
+      const name = people.names?.find((name) => name.metadata.primary);
+      return {
+        email: email?.value,
+        name: name?.displayName,
+        photo: photo?.url,
+      };
+    });
 
-    return emails;
+    return peoples;
   }
 }

--- a/server/src/calender/calender.service.ts
+++ b/server/src/calender/calender.service.ts
@@ -3,7 +3,7 @@ import { BadRequestException, ConflictException, ForbiddenException, Inject, Inj
 import { calendar_v3 } from 'googleapis';
 import { extractRoomByEmail, isRoomAvailable, validateEmail } from './util/calender.util';
 import { AuthService } from '../auth/auth.service';
-import { DeleteResponse, EventResponse, EventUpdateResponse, IConferenceRoom, IAttendeeInformation } from '@quickmeet/shared';
+import { DeleteResponse, EventResponse, EventUpdateResponse, IConferenceRoom, IPeopleInformation } from '@quickmeet/shared';
 import { GoogleApiService } from 'src/google-api/google-api.service';
 
 @Injectable()
@@ -417,11 +417,11 @@ export class CalenderService {
     return floors;
   }
 
-  async searchPeople(client: OAuth2Client, emailQuery: string): Promise<IAttendeeInformation[]> {
+  async searchPeople(client: OAuth2Client, emailQuery: string): Promise<IPeopleInformation[]> {
     const response = await this.googleApiService.searchPeople(client, emailQuery);
-    const peoples: IAttendeeInformation[] = response.map((people) => {
+    const peoples: IPeopleInformation[] = response.map((people) => {
       const email = people.emailAddresses.find((email) => email.metadata.primary && email.metadata.verified);
-      const photo = people.photos.find((photo) => photo.metadata.primary);
+      const photo = people.photos?.find((photo) => photo.metadata.primary);
       const name = people.names?.find((name) => name.metadata.primary);
       return {
         email: email?.value,

--- a/server/src/google-api/google-api.service.ts
+++ b/server/src/google-api/google-api.service.ts
@@ -222,7 +222,7 @@ export class GoogleApiService implements IGoogleApiService {
     const [err, res]: [GaxiosError, GaxiosResponse<people_v1.Schema$SearchDirectoryPeopleResponse>] = await to(
       peopleService.people.searchDirectoryPeople({
         query,
-        readMask: 'emailAddresses',
+        readMask: 'emailAddresses,photos,names',
         pageSize: 10,
         sources: ['DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE'],
       }),

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -10,4 +10,4 @@ export {
   StatusTypes,
 } from './dto';
 
-export { IConferenceRoom, IAttendeeInformation } from './interfaces';
+export { IConferenceRoom, IPeopleInformation } from './interfaces';

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -10,4 +10,4 @@ export {
   StatusTypes,
 } from './dto';
 
-export { IConferenceRoom } from './interfaces';
+export { IConferenceRoom, IAttendeeInformation } from './interfaces';

--- a/shared/interfaces/attendee-information.interface.ts
+++ b/shared/interfaces/attendee-information.interface.ts
@@ -1,0 +1,5 @@
+export interface IAttendeeInformation {
+  email?: string;
+  name?: string;
+  photo?: string;
+}

--- a/shared/interfaces/index.ts
+++ b/shared/interfaces/index.ts
@@ -1,2 +1,2 @@
 export * from './conference-room.interface';
-export * from './attendee-information.interface';
+export * from './people-information.interface';

--- a/shared/interfaces/index.ts
+++ b/shared/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './conference-room.interface';
+export * from './attendee-information.interface';

--- a/shared/interfaces/people-information.interface.ts
+++ b/shared/interfaces/people-information.interface.ts
@@ -1,4 +1,4 @@
-export interface IAttendeeInformation {
+export interface IPeopleInformation {
   email?: string;
   name?: string;
   photo?: string;


### PR DESCRIPTION
## What
Resolves : #163 

## How
Instead of only sending the `email` from the server now an object of `{email, name, photos}` are being sent to the client. Which renders the attendees suggestions.

## Screenshot
  
![issue-163](https://github.com/user-attachments/assets/68f135b7-b7f5-43b8-ad96-d29ca2b54aea)
