### PR TITLE
feat: support for multiple languages #164

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,10 +22,12 @@
     "@types/react-dom": "^18.3.0",
     "axios": "^1.7.7",
     "dayjs": "^1.11.13",
+    "i18next": "^24.2.2",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.4.1",
+    "react-i18next": "^15.4.0",
     "react-router-dom": "^6.26.2",
     "web-vitals": "^2.1.4"
   },

--- a/client/src/components/AttendeeInput.tsx
+++ b/client/src/components/AttendeeInput.tsx
@@ -1,3 +1,4 @@
+import { useLocales } from '@/config/i18n';
 import { useApi } from '@/context/ApiContext';
 import { isEmailValid } from '@/helpers/utility';
 import PeopleAltRoundedIcon from '@mui/icons-material/PeopleAltRounded';
@@ -19,6 +20,7 @@ interface AttendeeInputProps {
 export default function AttendeeInput({ id, onChange, value, type }: AttendeeInputProps) {
   const [options, setOptions] = useState<IPeopleInformation[]>([]);
   const [textInput, setTextInput] = useState('');
+  const { locale } = useLocales();
 
   const api = useApi();
 
@@ -161,7 +163,7 @@ export default function AttendeeInput({ id, onChange, value, type }: AttendeeInp
               onChange={(e) => setTextInput(e.target.value)}
               type={type}
               variant="standard"
-              placeholder="Attendees"
+              placeholder={locale.placeholder.attendees}
               slotProps={{
                 input: {
                   ...params.InputProps,

--- a/client/src/components/DeleteConfirmationView.tsx
+++ b/client/src/components/DeleteConfirmationView.tsx
@@ -7,6 +7,7 @@ import ArrowBackIosRoundedIcon from '@mui/icons-material/ArrowBackIosRounded';
 import { EventResponse } from '@quickmeet/shared';
 import { chromeBackground, isChromeExt } from '@helpers/utility';
 import EventCard from './EventCard';
+import { useLocales } from '@/config/i18n';
 
 interface DeleteConfirmationViewProps {
   handleNegativeClick: () => void;
@@ -19,6 +20,7 @@ export default function DeleteConfirmationView({ event, open, handleNegativeClic
   if (!open) return <></>;
 
   const background: SxProps<Theme> = isChromeExt ? { ...chromeBackground } : { background: '#F8F8F8' };
+  const { locale } = useLocales();
   return (
     <Box
       sx={{
@@ -57,7 +59,7 @@ export default function DeleteConfirmationView({ event, open, handleNegativeClic
         }}
       >
         <Typography variant="h4" fontWeight={700}>
-          Are you sure you want to permanently delete this event?
+          {locale.info.deleteEventConfirmation}
         </Typography>
         {event && (
           <Box
@@ -74,7 +76,7 @@ export default function DeleteConfirmationView({ event, open, handleNegativeClic
               borderRadius: 2,
             }}
           >
-            <EventCard event={event} hideMenu={true} handleEditClick={() => { }} onDelete={() => { }} />
+            <EventCard event={event} hideMenu={true} handleEditClick={() => {}} onDelete={() => {}} />
           </Box>
         )}
 
@@ -108,7 +110,7 @@ export default function DeleteConfirmationView({ event, open, handleNegativeClic
                 textTransform: 'none',
               }}
             >
-              Delete
+              {locale.buttonText.delete}
             </Typography>
           </Button>
 
@@ -136,7 +138,7 @@ export default function DeleteConfirmationView({ event, open, handleNegativeClic
             ]}
           >
             <Typography variant="subtitle2" fontWeight={700}>
-              Cancel
+              {locale.buttonText.cancel}
             </Typography>
           </Button>
         </Box>

--- a/client/src/components/RoomsDropdown.tsx
+++ b/client/src/components/RoomsDropdown.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from 'react';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { IConferenceRoom } from '@quickmeet/shared';
 import { IAvailableRoomsDropdownOption } from '@/helpers/types';
+import { useLocales } from '@/config/i18n';
 
 interface DropdownProps {
   id: string;
@@ -86,6 +87,7 @@ const StyledHintTypography = styled(Typography)(({ theme }) => ({
 }));
 
 const RenderNoRooms = ({ icon }: { icon?: ReactElement }) => {
+  const { locale } = useLocales();
   return (
     <Box
       sx={{
@@ -96,7 +98,7 @@ const RenderNoRooms = ({ icon }: { icon?: ReactElement }) => {
       {icon && icon}
 
       <StyledHintTypography ml={2} variant="subtitle2">
-        No rooms available
+        {locale.info.noRooms}
       </StyledHintTypography>
     </Box>
   );

--- a/client/src/config/i18n.ts
+++ b/client/src/config/i18n.ts
@@ -1,0 +1,32 @@
+import { LOCALES, type LocaleType } from '@/config/locales';
+import i18next from 'i18next';
+import { initReactI18next, useTranslation } from 'react-i18next';
+
+export const initI18n = () => {
+  i18next.use(initReactI18next).init({
+    fallbackLng: 'en',
+    resources: LOCALES.reduce(
+      (acc, { code, locale }) => {
+        acc[code] = { translation: locale };
+        return acc;
+      },
+      {} as Record<string, { translation: LocaleType }>,
+    ),
+  });
+};
+
+export const useLocales = () => {
+  const { i18n } = useTranslation();
+  const currentLanguage = i18n.language;
+  const locale = i18n.getResourceBundle(currentLanguage, 'translation') as LocaleType;
+
+  const changeLanguage = (language: string) => {
+    i18n.changeLanguage(language);
+  };
+
+  return {
+    locale,
+    currentLanguage,
+    changeLanguage,
+  };
+};

--- a/client/src/config/locales.ts
+++ b/client/src/config/locales.ts
@@ -1,0 +1,13 @@
+import en from '@/locales/en.json';
+import no from '@/locales/no.json';
+
+export type LocaleType = typeof en;
+interface ILocale {
+  code: string;
+  name: string;
+  locale: LocaleType;
+}
+export const LOCALES: ILocale[] = [
+  { code: 'en', name: 'English', locale: en },
+  { code: 'no', name: 'Norwegian', locale: no },
+] as const;

--- a/client/src/context/PreferencesContext.tsx
+++ b/client/src/context/PreferencesContext.tsx
@@ -1,5 +1,6 @@
 import { constants } from '@/config/constants';
 import { CacheService, CacheServiceFactory } from '@/helpers/cache';
+import { useLocales } from '@/config/i18n';
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 
 interface Preferences {
@@ -7,6 +8,7 @@ interface Preferences {
   seats: number;
   title?: string;
   floor?: string;
+  language?: string;
 }
 
 interface PreferencesContextType {
@@ -24,6 +26,7 @@ const defaultPreferences = {
   duration: 30,
   seats: 1,
   title: constants.defaultTitle,
+  language: 'en',
 };
 
 export const PreferencesProvider = ({ children }: PreferencesProviderProps) => {
@@ -32,8 +35,10 @@ export const PreferencesProvider = ({ children }: PreferencesProviderProps) => {
     duration: defaultPreferences.duration,
     seats: defaultPreferences.seats,
     title: defaultPreferences.title,
+    language: defaultPreferences.language,
   });
   const [loading, setLoading] = useState(true);
+  const { changeLanguage, currentLanguage } = useLocales();
 
   useEffect(() => {
     const loadPreferences = async () => {
@@ -52,6 +57,9 @@ export const PreferencesProvider = ({ children }: PreferencesProviderProps) => {
   useEffect(() => {
     if (!preferences.title) {
       preferences.title = defaultPreferences.title;
+    }
+    if (preferences.language && preferences.language !== currentLanguage) {
+      changeLanguage(preferences.language);
     }
 
     cacheService.save('preferences', JSON.stringify(preferences));

--- a/client/src/helpers/utility.ts
+++ b/client/src/helpers/utility.ts
@@ -1,4 +1,5 @@
 import Api from '@/api/api';
+import { LOCALES } from '@/config/locales';
 import { ROUTES } from '@config/routes';
 import { secrets } from '@config/secrets';
 import { ApiResponse } from '@quickmeet/shared';
@@ -141,6 +142,12 @@ export function convertToLocaleDate(dateStr?: string) {
 export const createDropdownOptions = (options: string[], type: 'time' | 'default' = 'default') => {
   return (options || []).map((option) => ({ value: option, text: type === 'time' ? formatMinsToHM(Number(option), 'm') : option }));
 };
+export const createLanguageOptions = () => {
+  return LOCALES.map(({ code, name }) => ({
+    value: code,
+    text: name,
+  }));
+};
 
 export const renderError = async (err: ApiResponse<any>, navigate: NavigateFunction) => {
   const { status, statusCode, message, redirect } = err;
@@ -148,7 +155,7 @@ export const renderError = async (err: ApiResponse<any>, navigate: NavigateFunct
     if (statusCode === 401) {
       try {
         await new Api().logout();
-      } catch (error) { }
+      } catch (error) {}
       navigate(ROUTES.signIn);
     } else if (statusCode === 400) {
       toast.error('Input missing fields');

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -8,7 +8,8 @@ import { PreferencesProvider } from './context/PreferencesContext';
 import { ApiProvider } from '@/context/ApiContext';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-
+import { initI18n } from '@/config/i18n';
+initI18n();
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <StyledEngineProvider injectFirst>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1,0 +1,45 @@
+{
+  "buttonText": {
+    "preferences": "Preferences",
+    "support": "Support",
+    "save": "Save",
+    "saveChanges": "Save Changes",
+    "newEvent": "New Event",
+    "myEvents": "My Events",
+    "bookNow": "Book Now",
+    "reportBug": "REPORT A BUG",
+    "requestFeature": "REQUEST A FEATURE",
+    "confirm": "Confirm",
+    "cancel": "Cancel",
+    "delete": "Delete"
+  },
+  "error": {
+    "invalidEmail": "Invalid email entered",
+    "duplicateEmail": "Duplicate email entered",
+    "failedToRetieveCallbackUrl": "Failed to retrieve oauth callback url",
+    "missingFields": "Input missing fields",
+    "selectEventToDelete": "Please select the event to delete",
+    "roomNotUpdated": "Room was not updated",
+    "loginNotComplete": "Couldn't complete request. Redirecting to login page"
+  },
+  "success": {
+    "savedSuccessfully": "Saved successfully"
+  },
+  "info": {
+    "createMeeting": "Create meet link",
+    "defaultTitle": "Quick Meeting",
+    "deleteEventConfirmation": "Are you sure you want to permanently delete this event?",
+    "noEvents": "No events to show",
+    "noRooms": "No rooms available",
+    "logoutConfirmation": "Are you sure you want to logout?",
+    "logoutInfo": "This will revoke the application permissions and would require to approve them again when trying to log back in"
+  },
+  "placeholder": {
+    "attendees": "Attendees",
+    "selectFloor": "Select preferred floor",
+    "selectDuration": "Select preferred meeting duration",
+    "selectRoomCapacity": "Select preferred room capacity",
+    "selectLanguage": "Select preferred language",
+    "invalidEmail": "Invalid email entered"
+  }
+}

--- a/client/src/locales/no.json
+++ b/client/src/locales/no.json
@@ -1,0 +1,45 @@
+{
+  "buttonText": {
+    "preferences": "Preferanser",
+    "support": "Støtte",
+    "save": "Spare",
+    "saveChanges": "Lagre endringer",
+    "newEvent": "Ny begivenhet",
+    "myEvents": "Mine hendelser",
+    "bookNow": "Bestill nå",
+    "reportBug": "RAPPORTER EN FEIL",
+    "requestFeature": "BE EN FUNKSJON",
+    "confirm": "Bekrefte",
+    "cancel": "Kansellere",
+    "delete": "Slett"
+  },
+  "error": {
+    "invalidEmail": "Ugyldig e-post angitt",
+    "duplicateEmail": "Duplikat e-post oppgitt",
+    "failedToRetieveCallbackUrl": "Kunne ikke hente oauth tilbakeringingsadress",
+    "missingFields": "Skriv inn manglende felt",
+    "selectEventToDelete": "Velg arrangementet du vil slette",
+    "roomNotUpdated": "Rommet ble ikke oppdatert",
+    "loginNotComplete": "Kunne ikke fullføre forespørselen. Omdirigerer til påloggingssiden"
+  },
+  "success": {
+    "savedSuccessfully": "Lagret vellykket"
+  },
+  "info": {
+    "createMeeting": "Opprett møtelink",
+    "defaultTitle": "Rask møte",
+    "deleteEventConfirmation": "Er du sikker på at du vil slette denne hendelsen permanent?",
+    "noEvents": "Ingen hendelser å vise",
+    "noRooms": "Ingen rom tilgjengelig",
+    "logoutConfirmation": "Er du sikker på at du vil logge ut?",
+    "logoutInfo": "Dette vil tilbakekalle applikasjonstillatelsene og vil kreve å godkjenne dem på nytt når du prøver å logge på igjen"
+  },
+  "placeholder": {
+    "attendees": "Deltakere",
+    "selectFloor": "Velg ønsket etasje",
+    "selectDuration": "Velg ønsket møtevarighet",
+    "selectRoomCapacity": "Velg ønsket romkapasitet",
+    "selectLanguage": "Velg ønsket språk",
+    "invalidEmail": "Ugyldig e-postadresse"
+  }
+}

--- a/client/src/pages/Home/BookRoomView/index.tsx
+++ b/client/src/pages/Home/BookRoomView/index.tsx
@@ -29,6 +29,7 @@ import 'dayjs/locale/en-gb';
 import { useEffect, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
+import { useLocales } from '@/config/i18n';
 
 const createRoomDropdownOptions = (rooms: IConferenceRoom[]) => {
   return (rooms || []).map((room) => ({ value: room.email, text: room.name, seats: room.seats, floor: room.floor }) as RoomsDropdownOption);
@@ -41,6 +42,9 @@ interface BookRoomViewProps {
 export default function BookRoomView({ onRoomBooked }: BookRoomViewProps) {
   // Context or global state
   const { preferences } = usePreferences();
+
+  // Locales
+  const { locale } = useLocales();
 
   // loading states
   const [bookClickLoading, setBookClickLoading] = useState(false);
@@ -411,7 +415,7 @@ export default function BookRoomView({ onRoomBooked }: BookRoomViewProps) {
             >
               <Checkbox checked={formData.conference} value={formData.conference} onChange={(e) => handleInputChange('conference', e.target.checked)} />
               <Typography variant="subtitle1" ml={0.5}>
-                Create meet link
+                {locale.info.createMeeting}
               </Typography>
             </Box>
           </Box>
@@ -452,7 +456,7 @@ export default function BookRoomView({ onRoomBooked }: BookRoomViewProps) {
           ]}
         >
           <Typography variant="h6" fontWeight={700}>
-            Book now
+            {locale.buttonText.bookNow}
           </Typography>
         </LoadingButton>
       </Box>

--- a/client/src/pages/Home/MyEventsView/EditEventsView.tsx
+++ b/client/src/pages/Home/MyEventsView/EditEventsView.tsx
@@ -32,6 +32,7 @@ import 'dayjs/locale/en-gb';
 import { useEffect, useRef, useState } from 'react';
 import { EventResponse, IConferenceRoom, IAvailableRooms, IPeopleInformation } from '@quickmeet/shared';
 import { useNavigate } from 'react-router-dom';
+import { useLocales } from '@/config/i18n';
 
 const createRoomDropdownOptions = (rooms: IConferenceRoom[]) => {
   return (rooms || []).map((room) => ({ value: room.email, text: room.name, seats: room.seats, floor: room.floor }) as RoomsDropdownOption);
@@ -70,6 +71,9 @@ interface EditEventsViewProps {
 export default function EditEventsView({ open, event, handleClose, currentRoom, onEditConfirmed, editLoading }: EditEventsViewProps) {
   // Context or global state
   const { preferences } = usePreferences();
+
+  // Locales
+  const { locale } = useLocales();
 
   // Dropdown options state
   const [timeOptions, setTimeOptions] = useState<DropdownOption[]>([]);
@@ -441,7 +445,7 @@ export default function EditEventsView({ open, event, handleClose, currentRoom, 
               >
                 <Checkbox checked={formData.conference} value={formData.conference} onChange={(e) => handleInputChange('conference', e.target.checked)} />
                 <Typography variant="subtitle1" ml={0.5}>
-                  Create meet link
+                  {locale.info.createMeeting}
                 </Typography>
               </Box>
             </Box>
@@ -481,7 +485,7 @@ export default function EditEventsView({ open, event, handleClose, currentRoom, 
           ]}
         >
           <Typography variant="h6" fontWeight={700}>
-            Save changes
+            {locale.buttonText.saveChanges}
           </Typography>
         </LoadingButton>
 
@@ -505,7 +509,7 @@ export default function EditEventsView({ open, event, handleClose, currentRoom, 
           }}
         >
           <Typography variant="subtitle2" fontWeight={700}>
-            Cancel
+            {locale.buttonText.cancel}
           </Typography>
         </Button>
       </Box>

--- a/client/src/pages/Home/MyEventsView/index.tsx
+++ b/client/src/pages/Home/MyEventsView/index.tsx
@@ -14,6 +14,7 @@ import toast from 'react-hot-toast';
 import EditEventsView from './EditEventsView';
 import dayjs from 'dayjs';
 import DatePickerPopper from '@/pages/Home/MyEventsView/DatePickerPopper';
+import { useLocales } from '@/config/i18n';
 
 interface MyEventsViewProps {
   redirectedDate?: string;
@@ -30,6 +31,7 @@ export default function MyEventsView({ redirectedDate }: MyEventsViewProps) {
   const [currentRoom, setCurrentRoom] = useState<IConferenceRoom | undefined>();
   const api = useApi();
   const { preferences } = usePreferences();
+  const { locale } = useLocales();
 
   const [datePickerOpen, setDatePickerOpen] = useState<boolean>(false);
 
@@ -103,7 +105,7 @@ export default function MyEventsView({ redirectedDate }: MyEventsViewProps) {
     setLoading(true);
 
     if (!deleteEventId) {
-      toast.error('Please select the event to delete');
+      toast.error(locale.error.selectEventToDelete);
       return;
     }
 
@@ -125,7 +127,7 @@ export default function MyEventsView({ redirectedDate }: MyEventsViewProps) {
 
   const onEditConfirmed = async (data: FormData) => {
     if (!data || !data.eventId || !data.room) {
-      toast.error('Room was not updated');
+      toast.error(locale.error.roomNotUpdated);
       return;
     }
 
@@ -158,7 +160,7 @@ export default function MyEventsView({ redirectedDate }: MyEventsViewProps) {
 
     const res = await api.updateEvent(eventId, payload);
     if (res?.redirect) {
-      toast.error("Couldn't complete request. Redirecting to login page");
+      toast.error(locale.error.loginNotComplete);
       setTimeout(() => {
         navigate(ROUTES.signIn);
       }, 1000);
@@ -266,7 +268,7 @@ export default function MyEventsView({ redirectedDate }: MyEventsViewProps) {
         <>
           {events.length == 0 ? (
             <Typography mt={3} variant="h6">
-              No events to show
+              {locale.info.noEvents}
             </Typography>
           ) : (
             <Box

--- a/client/src/pages/Home/TopNavigationBar.tsx
+++ b/client/src/pages/Home/TopNavigationBar.tsx
@@ -2,6 +2,7 @@ import { Box, IconButton, styled, SxProps, Theme, ToggleButton, ToggleButtonGrou
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/config/routes';
+import { useLocales } from '@/config/i18n';
 
 const TopBar = styled(Box)(({ theme }) => ({
   paddingTop: theme.spacing(1.5),
@@ -55,6 +56,7 @@ interface TopNavigationBarProps {
 
 const TopNavigationBar = ({ sx, tabIndex, handleTabChange }: TopNavigationBarProps) => {
   const navigate = useNavigate();
+  const { locale } = useLocales();
 
   const handleChange = (_: React.SyntheticEvent | null, newValue: number) => {
     if (newValue !== null) {
@@ -63,7 +65,7 @@ const TopNavigationBar = ({ sx, tabIndex, handleTabChange }: TopNavigationBarPro
   };
 
   const onSettingClick = () => {
-    navigate(ROUTES.settings)
+    navigate(ROUTES.settings);
   };
 
   return (
@@ -83,12 +85,11 @@ const TopNavigationBar = ({ sx, tabIndex, handleTabChange }: TopNavigationBarPro
       >
         <StyledToggleButtonGroup value={tabIndex} exclusive onChange={handleChange} aria-label="event tabs" fullWidth={true}>
           <StyledToggleButton value={0} aria-label="new event" fullWidth={true}>
-            New Event
+            {locale.buttonText.newEvent}
           </StyledToggleButton>
           <StyledToggleButton value={1} aria-label="my events" fullWidth={true}>
-            My Events
+            {locale.buttonText.myEvents}
           </StyledToggleButton>
-
         </StyledToggleButtonGroup>
       </Box>
 

--- a/client/src/pages/Settings/LogoutView.tsx
+++ b/client/src/pages/Settings/LogoutView.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { ROUTES } from '@/config/routes';
 import { useNavigate } from 'react-router-dom';
 import { useApi } from '@/context/ApiContext';
+import { useLocales } from '@/config/i18n';
 
 interface LogoutViewProps {
   handleCancel: () => void;
@@ -13,6 +14,7 @@ export default function LogoutView({ handleCancel }: LogoutViewProps) {
   const [loading, setLoading] = useState(false);
   const api = useApi();
   const navigate = useNavigate();
+  const { locale } = useLocales();
 
   const onConfirmClick = async () => {
     setLoading(true);
@@ -57,7 +59,7 @@ export default function LogoutView({ handleCancel }: LogoutViewProps) {
             variant="h3"
             component={'div'}
           >
-            Are you sure you want to logout?
+            {locale.info.logoutConfirmation}
           </Typography>
           <Typography
             sx={[
@@ -72,7 +74,7 @@ export default function LogoutView({ handleCancel }: LogoutViewProps) {
             variant="body1"
             component={'div'}
           >
-            This will revoke the application permissions and would require to approve them again when trying to log back in
+            {locale.info.logoutInfo}
           </Typography>
         </Box>
       </Box>
@@ -107,7 +109,7 @@ export default function LogoutView({ handleCancel }: LogoutViewProps) {
           ]}
         >
           <Typography variant="h6" fontWeight={700}>
-            Confirm
+            {locale.buttonText.confirm}
           </Typography>
         </LoadingButton>
 
@@ -131,7 +133,7 @@ export default function LogoutView({ handleCancel }: LogoutViewProps) {
           }}
         >
           <Typography variant="subtitle2" fontWeight={700}>
-            Cancel
+            {locale.buttonText.cancel}
           </Typography>
         </Button>
       </Box>

--- a/client/src/pages/Settings/PreferenceView.tsx
+++ b/client/src/pages/Settings/PreferenceView.tsx
@@ -2,7 +2,7 @@ import { DropdownOption } from '@/components/Dropdown';
 import Dropdown from '@/components/Dropdown';
 import StyledTextField from '@/components/StyledTextField';
 import { usePreferences } from '@/context/PreferencesContext';
-import { createDropdownOptions, isChromeExt, populateDurationOptions, populateRoomCapacity, renderError } from '@/helpers/utility';
+import { createDropdownOptions, createLanguageOptions, isChromeExt, populateDurationOptions, populateRoomCapacity, renderError } from '@/helpers/utility';
 import { Box, Button, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
@@ -12,6 +12,9 @@ import HourglassBottomRoundedIcon from '@mui/icons-material/HourglassBottomRound
 import StairsIcon from '@mui/icons-material/Stairs';
 import TitleIcon from '@mui/icons-material/Title';
 import { useApi } from '@/context/ApiContext';
+import { useLocales } from '@/config/i18n';
+import i18next, { changeLanguage } from 'i18next';
+import TranslateIcon from '@mui/icons-material/Translate';
 
 export default function PreferenceView() {
   // Form state
@@ -20,12 +23,14 @@ export default function PreferenceView() {
     duration: '30',
     seats: 1,
     title: '',
+    language: 'en',
   });
 
   // Dropdown options state
   const [floorOptions, setFloorOptions] = useState<DropdownOption[]>([]);
   const [durationOptions, setDurationOptions] = useState<DropdownOption[]>([]);
   const [roomCapacityOptions, setRoomCapacityOptions] = useState<DropdownOption[]>([]);
+  const [languageOptions, setLanguageOptions] = useState<DropdownOption[]>([]);
 
   // Utilities and services
   const api = useApi();
@@ -33,6 +38,9 @@ export default function PreferenceView() {
 
   // Context or global state
   const { preferences, setPreferences } = usePreferences();
+
+  // locale
+  const { locale } = useLocales();
 
   // Derived data
   const durations = populateDurationOptions();
@@ -45,13 +53,15 @@ export default function PreferenceView() {
       setFloorOptions(floorOptions);
       setRoomCapacityOptions(createDropdownOptions(capacities));
       setDurationOptions(createDropdownOptions(durations, 'time'));
+      setLanguageOptions(createLanguageOptions());
 
-      const { floor, duration, title, seats } = preferences;
+      const { floor, duration, title, seats, language } = preferences;
       setFormData({
         floor: floor || '',
         title: title || '',
         duration: String(duration) || durations[0],
         seats: seats || 1,
+        language: language || 'en',
       });
     };
 
@@ -93,9 +103,12 @@ export default function PreferenceView() {
       floor: formData.floor,
       title: formData.title,
       duration: Number(formData.duration),
+      language: formData.language,
     });
 
-    toast.success('Saved successfully!');
+    changeLanguage(formData.language).then(() => {
+      toast.success(i18next.t('success.savedSuccessfully'));
+    });
   };
 
   return (
@@ -192,6 +205,24 @@ export default function PreferenceView() {
             placeholder="Add preferred title"
             onChange={handleInputChange}
           />
+
+          <Dropdown
+            sx={{ height: '60px', borderBottomLeftRadius: 15, borderBottomRightRadius: 15 }}
+            id="language"
+            placeholder={locale.placeholder.selectLanguage}
+            value={formData.language + ''}
+            options={languageOptions}
+            onChange={handleInputChange}
+            icon={
+              <TranslateIcon
+                sx={[
+                  (theme) => ({
+                    color: theme.palette.grey[50],
+                  }),
+                ]}
+              />
+            }
+          />
         </Box>
       </Box>
 
@@ -222,7 +253,7 @@ export default function PreferenceView() {
           ]}
         >
           <Typography variant="h6" fontWeight={700}>
-            Save
+            {locale.buttonText.save}
           </Typography>
         </Button>
       </Box>

--- a/client/src/pages/Settings/SupportView.tsx
+++ b/client/src/pages/Settings/SupportView.tsx
@@ -3,6 +3,7 @@ import { secrets } from '@config/secrets';
 import LightbulbRoundedIcon from '@mui/icons-material/LightbulbRounded';
 import { constants } from '@/config/constants';
 import { Box, Button, styled } from '@mui/material';
+import { useLocales } from '@/config/i18n';
 
 const SettingsButton = styled(Button)(({ theme: _ }) => ({
   boxShadow: 'none',
@@ -18,6 +19,8 @@ const SettingsButton = styled(Button)(({ theme: _ }) => ({
 }));
 
 export default function SupportView() {
+  const { locale } = useLocales();
+
   const onReportBugClick = () => {
     const url = constants.bugReportUrl;
     if (secrets.appEnvironment === 'chrome') {
@@ -76,7 +79,7 @@ export default function SupportView() {
             onClick={onReportBugClick}
             startIcon={<BugReportRoundedIcon sx={{ mr: 1 }} />}
           >
-            Report a bug
+            {locale.buttonText.reportBug}
           </SettingsButton>
 
           <SettingsButton
@@ -89,7 +92,7 @@ export default function SupportView() {
             onClick={onRequestFeatureClick}
             startIcon={<LightbulbRoundedIcon sx={{ mr: 1 }} />}
           >
-            Request a feature
+            {locale.buttonText.requestFeature}
           </SettingsButton>
         </Box>
       </Box>

--- a/client/src/pages/Settings/index.tsx
+++ b/client/src/pages/Settings/index.tsx
@@ -11,6 +11,7 @@ import ExitToAppRoundedIcon from '@mui/icons-material/ExitToAppRounded';
 import PreferenceView from '@/pages/Settings/PreferenceView';
 import SupportView from '@/pages/Settings/SupportView';
 import LogoutView from '@/pages/Settings/LogoutView';
+import { useLocales } from '@/config/i18n';
 
 const TopBar = styled(Box)(({ theme }) => ({
   paddingTop: theme.spacing(1.5),
@@ -57,6 +58,7 @@ const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
 export default function Settings() {
   const [tabIndex, setTabIndex] = useState(0);
   const navigate = useNavigate();
+  const { locale } = useLocales();
 
   const handleTabChange = (_: React.SyntheticEvent | null, newValue: number) => {
     if (newValue !== null) {
@@ -119,10 +121,10 @@ export default function Settings() {
           >
             <StyledToggleButtonGroup sx={{ mx: 0 }} value={tabIndex} exclusive onChange={handleTabChange} aria-label="event tabs" fullWidth={true}>
               <StyledToggleButton value={0} aria-label="new event" fullWidth={true}>
-                Preferences
+                {locale.buttonText.preferences}
               </StyledToggleButton>
               <StyledToggleButton value={1} aria-label="my events" fullWidth={true}>
-                Support
+                {locale.buttonText.support}
               </StyledToggleButton>
             </StyledToggleButtonGroup>
           </Box>

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,10 +38,12 @@
         "@types/react-dom": "^18.3.0",
         "axios": "^1.7.7",
         "dayjs": "^1.11.13",
+        "i18next": "^24.2.2",
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hot-toast": "^2.4.1",
+        "react-i18next": "^15.4.0",
         "react-router-dom": "^6.26.2",
         "web-vitals": "^2.1.4"
       },
@@ -6463,6 +6465,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -6529,6 +6539,36 @@
       "optional": true,
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "24.2.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.2.tgz",
+      "integrity": "sha512-NE6i86lBCKRYZa5TaUDkU5S4HFgLIEJRLr3Whf2psgaxBleQ2LC1YW1Vc+SCgkAW7VEzndT6al6+CzegSUHcTQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -9013,6 +9053,27 @@
         "react-dom": ">=16"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.4.0.tgz",
+      "integrity": "sha512-Py6UkX3zV08RTvL6ZANRoBh9sL/ne6rQq79XlkHEdd82cZr2H9usbWpUNVadJntIZP2pu3M2rL1CN+5rQYfYFw==",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
@@ -10610,7 +10671,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10818,6 +10879,14 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack": {


### PR DESCRIPTION
- Resolves: #164 

## What
- Adds `i18next` , `react-i18next` packages for managing localization
- Saves the user's language preference in local storage.
- Retrieves the user language preference.
- Adds partial language support for `EN` and `NO`. [ The whole application's text hasn't been converted yet. ]

## How
- Introduces a `useLocales` hook that gives translations based on the user's preferences. The hook can be used like below:
```
const { locale } = useLocales();
toast.error(locale.error.invalidEmail)
```
